### PR TITLE
Fix references in docs

### DIFF
--- a/lib/prima_auth0_ex/auth0_credentials.ex
+++ b/lib/prima_auth0_ex/auth0_credentials.ex
@@ -1,7 +1,7 @@
 defmodule PrimaAuth0Ex.Auth0Credentials do
-  @moduledoc false
+  @moduledoc "Credentials to access Auth0"
 
-  @type t() :: %__MODULE__{base_url: String.t(), client_id: String.t(), client_secret: String.t()}
+  @type t :: %__MODULE__{base_url: String.t(), client_id: String.t(), client_secret: String.t()}
   @enforce_keys [:base_url, :client_id, :client_secret]
   defstruct [:base_url, :client_id, :client_secret]
 

--- a/lib/prima_auth0_ex/token_provider/token_info.ex
+++ b/lib/prima_auth0_ex/token_provider/token_info.ex
@@ -1,14 +1,11 @@
 defmodule PrimaAuth0Ex.TokenProvider.TokenInfo do
-  @moduledoc false
+  @moduledoc "Information related to a JWT, including the JWT itself and additional metadata"
 
   @enforce_keys [:jwt, :issued_at, :expires_at]
   @derive Jason.Encoder
   defstruct [:jwt, :kid, :issued_at, :expires_at]
 
-  @typedoc """
-  A JWT along with some useful metadata.
-  """
-  @type t() :: %__MODULE__{
+  @type t :: %__MODULE__{
           jwt: String.t(),
           issued_at: non_neg_integer(),
           expires_at: non_neg_integer(),


### PR DESCRIPTION
This PR fixes references to some types in the generated docs.

Turns out if you set `@moduledoc false` on a module, then `ex_doc` will ignore its types when generating documentation :D 