### PR TITLE
[PLATFORM-480]: [Auth0Ex] Understand how to enforce https on Redix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Added
+
+- New `:redis_ssl_enabled` and `:redis_ssl_allow_wildcard_certificates` options
+
 ## [0.4.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ config :prima_auth0_ex, :client,
   # AES 256 key used to encrypt tokens on the shared cache.
   # Can be generated via `:crypto.strong_rand_bytes(32) |> Base.encode64()`.
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
-  redis_connection_uri: "redis://redis:6379"
+  redis_connection_uri: "redis://redis:6379",
+  redis_ssl_enabled: false,
+  # Read here for more infos: https://hexdocs.pm/redix/Redix.html#module-ssl
+  redis_ssl_allow_wildcard_certificates: false
 ```
 
 **If the client will access APIs that perform validation of permissions, make sure that the API on Auth0 is configured to have both "Enable RBAC" and "Add Permissions in the Access Token" enabled.**

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ config :prima_auth0_ex, :client,
   cache_enabled: true,
   cache_namespace: "my-service",
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
-  redis_connection_uri: "redis://redis:6379"
+  redis_connection_uri: "redis://redis:6379",
+  redis_ssl_allow_wildcard_certificates: false
 
 config :prima_auth0_ex, :server,
   ignore_signature: false,

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,8 @@ config :prima_auth0_ex, :client,
   cache_namespace: "my-service",
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
   redis_connection_uri: "redis://redis:6379",
-  redis_ssl_allow_wildcard_certificates: false
+  redis_ssl_enabled: true,
+  redis_ssl_allow_wildcard_certificates: true
 
 config :prima_auth0_ex, :server,
   ignore_signature: false,

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,8 +10,8 @@ config :prima_auth0_ex, :client,
   cache_namespace: "my-service",
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
   redis_connection_uri: "redis://redis:6379",
-  redis_ssl_enabled: true,
-  redis_ssl_allow_wildcard_certificates: true
+  redis_ssl_enabled: false,
+  redis_ssl_allow_wildcard_certificates: false
 
 config :prima_auth0_ex, :server,
   ignore_signature: false,

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,7 +11,8 @@ config :prima_auth0_ex, :client,
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
   redis_connection_uri: "redis://redis:6379",
   redis_ssl_enabled: false,
-  redis_ssl_allow_wildcard_certificates: false
+  redis_ssl_allow_wildcard_certificates: false,
+  redis_ssl_disable_certificate_verification: false
 
 config :prima_auth0_ex, :server,
   ignore_signature: false,

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,8 +11,7 @@ config :prima_auth0_ex, :client,
   cache_encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",
   redis_connection_uri: "redis://redis:6379",
   redis_ssl_enabled: false,
-  redis_ssl_allow_wildcard_certificates: false,
-  redis_ssl_disable_certificate_verification: false
+  redis_ssl_allow_wildcard_certificates: false
 
 config :prima_auth0_ex, :server,
   ignore_signature: false,

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -62,16 +62,20 @@ defmodule PrimaAuth0Ex.Application do
         ]
       ]
     )
+    |> append_if(redis_ssl_disable_certificate_verification?(),
+      verify: :verify_none
+    )
   end
 
-  defp redis_ssl_enabled? do
-    client = Application.get_env(:prima_auth0_ex, :client, [])
-    client[:redis_ssl_enabled] || false
-  end
+  defp redis_ssl_enabled?, do: get_redis_option(:redis_ssl_enabled)
 
-  defp redis_ssl_allow_wildcard_certificates? do
+  defp redis_ssl_allow_wildcard_certificates?, do: get_redis_option(:redis_ssl_allow_wildcard_certificates)
+
+  defp redis_ssl_disable_certificate_verification?, do: get_redis_option(:redis_ssl_disable_certificate_verification)
+
+  defp get_redis_option(option) do
     client = Application.get_env(:prima_auth0_ex, :client, [])
-    client[:redis_ssl_allow_wildcard_certificates] || false
+    client[option] || false
   end
 
   defp first_jwks_fetch_sync do

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -63,7 +63,7 @@ defmodule PrimaAuth0Ex.Application do
     )
   end
 
-  defp redis_ssl_enabled?() do
+  defp redis_ssl_enabled? do
     client = Application.get_env(:prima_auth0_ex, :client, [])
     client[:redis_ssl_enabled] || false
   end

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -53,6 +53,7 @@ defmodule PrimaAuth0Ex.Application do
   def redis_ssl_opts do
     []
     |> append_if(redis_ssl_enabled?(), ssl: true)
+    # Read here for an explanation: https://hexdocs.pm/redix/Redix.html#module-ssl
     |> append_if(
       redis_ssl_allow_wildcard_certificates?(),
       socket_opts: [

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -60,9 +60,7 @@ defmodule PrimaAuth0Ex.Application do
         customize_hostname_check: [
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
         ]
-      ]
-    )
-    |> append_if(redis_ssl_disable_certificate_verification?(),
+      ],
       verify: :verify_none
     )
   end
@@ -70,8 +68,6 @@ defmodule PrimaAuth0Ex.Application do
   defp redis_ssl_enabled?, do: get_redis_option(:redis_ssl_enabled)
 
   defp redis_ssl_allow_wildcard_certificates?, do: get_redis_option(:redis_ssl_allow_wildcard_certificates)
-
-  defp redis_ssl_disable_certificate_verification?, do: get_redis_option(:redis_ssl_disable_certificate_verification)
 
   defp get_redis_option(option) do
     client = Application.get_env(:prima_auth0_ex, :client, [])

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -59,9 +59,9 @@ defmodule PrimaAuth0Ex.Application do
       socket_opts: [
         customize_hostname_check: [
           match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-        ]
-      ],
-      verify: :verify_none
+        ],
+        verify: :verify_none
+      ]
     )
   end
 


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-480

This PR tries to address the problem described [here](https://hexdocs.pm/redix/Redix.html#module-ssl) i.e. the need for an additional socket option to allow wildcard certificates and thus have successful verification when using ssl with Amazon Elasticache (which we need to be able to authenticate with our Redis).

We added two new config options:

- `:redis_ssl_enabled`,
- `:redis_ssl_allow_wildcard_certificates`

which default to `false` and can be used to enable ssl and, optionally, add the additional socket configuration.

Theoretically the `ssl` option could be specified in the redis uri (e.g. using "?ssl=true") but this doesn't seem to be standard and this way it seems more robust.

