### PR TITLE
[MOTOR-1644]: Metriche auth0 non funzionanti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+### Fixed
+
+- Rename the metric defined by the default telemetry handler from `retrieve_token:*` (invalid) to `auth0.token`
+
 ## [0.4.3] - 2022-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Next]
 
+## [0.4.4] - 2022-07-28
+
 ### Fixed
 
 - Rename the metric defined by the default telemetry handler from `retrieve_token:*` (invalid) to `auth0.token`

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ config :prima_auth0_ex, telemetry_reporter: TelemetryReporter
 
 At startup, the library will check if a reporter has been configured and then it will attach it as a handler.
 
-To work, the reporter needs to have an `increment` method like in Statix or Instruments, and it will then increment one of two counters: `retrieve_token:success` or `retrieve_token:failure`. Each counter will be tagged by `audience`.
+To work, the reporter needs to have an `increment` method like in Statix or Instruments, and it will then increment one of two counters: `auth0.token`. Each counter will be tagged by `audience` and `status` (`success` or `failure`).
 
 ## Development
 

--- a/lib/prima_auth0_ex/telemetry.ex
+++ b/lib/prima_auth0_ex/telemetry.ex
@@ -32,15 +32,12 @@ defmodule PrimaAuth0Ex.Telemetry.Handler do
   A pre-defined telemetry handler
   """
 
-  def handle_event([:prima_auth0_ex, :retrieve_token, :failure], %{count: count}, %{audience: audience}, %{
-        reporter: reporter
-      }) do
-    reporter.increment("retrieve_token:failure", count, tags: ["audience:#{audience}"])
-  end
-
-  def handle_event([:prima_auth0_ex, :retrieve_token, :success], %{count: count}, %{audience: audience}, %{
-        reporter: reporter
-      }) do
-    reporter.increment("retrieve_token:success", count, tags: ["audience:#{audience}"])
+  def handle_event(
+        [:prima_auth0_ex, :retrieve_token, status],
+        %{count: count},
+        %{audience: audience},
+        %{reporter: reporter}
+      ) do
+    reporter.increment("auth0.token", count, tags: ["audience:#{audience}", "status:#{status}"])
   end
 end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/MOTOR-1644

The `retrieve_token:success/failure` name of metric is invalid (it should be `retrive_token.success/failure`).

Since nobody used this feature until now, I have taken the opportunity to rename the metric to `auth0.token` and set the result as a tag `status:success/failure`.

