### PR TITLE
[PLATFORM-578]: [Auth0Ex] Wrong error handling on cache decrypt failure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @primait/shared-services

--- a/lib/prima_auth0_ex/token_provider/token_encryptor.ex
+++ b/lib/prima_auth0_ex/token_provider/token_encryptor.ex
@@ -25,7 +25,7 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptor do
     <<iv::binary-16, tag::binary-16, ciphertext::binary>> = Base.decode64!(encrypted)
 
     case :crypto.crypto_one_time_aead(:aes_256_gcm, token_encryption_key(), iv, ciphertext, @aad, tag, false) do
-      :error -> {:error, "something"}
+      :error -> {:error, "Failed to decrypt token"}
       decrypted -> {:ok, decrypted}
     end
   rescue

--- a/lib/prima_auth0_ex/token_provider/token_encryptor.ex
+++ b/lib/prima_auth0_ex/token_provider/token_encryptor.ex
@@ -23,9 +23,11 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptor do
   @spec decrypt(String.t()) :: {:ok, String.t()} | {:error, any()}
   def decrypt(encrypted) do
     <<iv::binary-16, tag::binary-16, ciphertext::binary>> = Base.decode64!(encrypted)
-    encrypted = :crypto.crypto_one_time_aead(:aes_256_gcm, token_encryption_key(), iv, ciphertext, @aad, tag, false)
 
-    {:ok, encrypted}
+    case :crypto.crypto_one_time_aead(:aes_256_gcm, token_encryption_key(), iv, ciphertext, @aad, tag, false) do
+      :error -> {:error, "something"}
+      decrypted -> {:ok, decrypted}
+    end
   rescue
     err -> {:error, err}
   end

--- a/test/prima_auth0_ex/token_provider/token_encryptor_test.ex
+++ b/test/prima_auth0_ex/token_provider/token_encryptor_test.ex
@@ -1,0 +1,35 @@
+defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
+  use ExUnit.Case, async: false
+
+  alias PrimaAuth0Ex.TestHelper
+  alias PrimaAuth0Ex.TokenProvider.TokenEncryptor
+
+  @token_encryption_key "eT4YutFXY/PCV5Kr6gBD/K2NxM60OqeXFux09te6Z80="
+
+  test "encrypts and decrypts correctly" do
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+
+    plaintext = "test"
+
+    {:ok, enc} = TokenEncryptor.encrypt(plaintext)
+    {:ok, dec} = TokenEncryptor.decrypt(enc)
+
+    assert plaintext == dec
+  end
+
+  test "decrypting fails with :error if key changes" do
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+
+    plaintext = "test"
+
+    {:ok, enc} = TokenEncryptor.encrypt(plaintext)
+
+    new_key = keygen()
+
+    TestHelper.set_client_env(:cache_encryption_key, new_key, false)
+
+    assert {:error, _} = TokenEncryptor.decrypt(enc)
+  end
+
+  defp keygen(), do: :crypto.strong_rand_bytes(32) |> Base.encode64()
+end

--- a/test/prima_auth0_ex/token_provider/token_encryptor_test.ex
+++ b/test/prima_auth0_ex/token_provider/token_encryptor_test.ex
@@ -17,7 +17,7 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
     assert plaintext == dec
   end
 
-  test "decrypting fails with :error if key changes" do
+  test "decrypting returns with :error if key changes" do
     TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
 
     plaintext = "test"
@@ -27,6 +27,26 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
     new_key = keygen()
 
     TestHelper.set_client_env(:cache_encryption_key, new_key, false)
+
+    assert {:error, _} = TokenEncryptor.decrypt(enc)
+  end
+
+  test "encrypting returns with :error if key is not binary" do
+    TestHelper.set_client_env(:cache_encryption_key, 1234, true)
+
+    plaintext = "test"
+
+    assert {:error, _} = TokenEncryptor.encrypt(plaintext)
+  end
+
+  test "decrypting returns with :error if key is not binary" do
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+
+    plaintext = "test"
+
+    {:ok, enc} = TokenEncryptor.encrypt(plaintext)
+
+    TestHelper.set_client_env(:cache_encryption_key, 1234, false)
 
     assert {:error, _} = TokenEncryptor.decrypt(enc)
   end

--- a/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
+++ b/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
@@ -24,7 +24,7 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
 
     {:ok, enc} = TokenEncryptor.encrypt("test")
 
-    new_key = keygen()
+    new_key = generate_key()
 
     TestHelper.set_client_env(:cache_encryption_key, new_key, reset?: false)
 
@@ -47,5 +47,5 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
     assert {:error, _} = TokenEncryptor.decrypt(enc)
   end
 
-  defp keygen, do: Base.encode64(:crypto.strong_rand_bytes(32))
+  defp generate_key, do: Base.encode64(:crypto.strong_rand_bytes(32))
 end

--- a/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
+++ b/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
@@ -9,7 +9,7 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
   @token_encryption_key "eT4YutFXY/PCV5Kr6gBD/K2NxM60OqeXFux09te6Z80="
 
   test "encrypts and decrypts correctly" do
-    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key)
 
     plaintext = "test"
 
@@ -20,35 +20,29 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
   end
 
   test "decrypting returns with :error if key changes" do
-    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key)
 
-    plaintext = "test"
-
-    {:ok, enc} = TokenEncryptor.encrypt(plaintext)
+    {:ok, enc} = TokenEncryptor.encrypt("test")
 
     new_key = keygen()
 
-    TestHelper.set_client_env(:cache_encryption_key, new_key, false)
+    TestHelper.set_client_env(:cache_encryption_key, new_key, reset?: false)
 
     assert {:error, _} = TokenEncryptor.decrypt(enc)
   end
 
   test "encrypting returns with :error if key is not binary" do
-    TestHelper.set_client_env(:cache_encryption_key, 1234, true)
+    TestHelper.set_client_env(:cache_encryption_key, 1234)
 
-    plaintext = "test"
-
-    assert {:error, _} = TokenEncryptor.encrypt(plaintext)
+    assert {:error, _} = TokenEncryptor.encrypt("test")
   end
 
   test "decrypting returns with :error if key is not binary" do
-    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key, true)
+    TestHelper.set_client_env(:cache_encryption_key, @token_encryption_key)
 
-    plaintext = "test"
+    {:ok, enc} = TokenEncryptor.encrypt("test")
 
-    {:ok, enc} = TokenEncryptor.encrypt(plaintext)
-
-    TestHelper.set_client_env(:cache_encryption_key, 1234, false)
+    TestHelper.set_client_env(:cache_encryption_key, 1234, reset?: false)
 
     assert {:error, _} = TokenEncryptor.decrypt(enc)
   end

--- a/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
+++ b/test/prima_auth0_ex/token_provider/token_encryptor_test.exs
@@ -1,4 +1,6 @@
 defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
+  @moduledoc false
+
   use ExUnit.Case, async: false
 
   alias PrimaAuth0Ex.TestHelper
@@ -51,5 +53,5 @@ defmodule PrimaAuth0Ex.TokenProvider.TokenEncryptorTest do
     assert {:error, _} = TokenEncryptor.decrypt(enc)
   end
 
-  defp keygen(), do: :crypto.strong_rand_bytes(32) |> Base.encode64()
+  defp keygen, do: Base.encode64(:crypto.strong_rand_bytes(32))
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,23 @@
 ExUnit.configure(exclude: :external)
 ExUnit.start()
+
+defmodule PrimaAuth0Ex.TestHelper do
+  import ExUnit.Callbacks
+
+  @spec set_client_env(term(), term(), boolean()) :: :ok
+  def set_client_env(key, value, false) do
+    Application.get_env(:prima_auth0_ex, :client, [])
+    |> Keyword.put(key, value)
+    |> then(&Application.put_env(:prima_auth0_ex, :client, &1))
+  end
+
+  def set_client_env(key, value, true) do
+    previous_value = Application.get_env(:prima_auth0_ex, :client, [])
+    updated_value = Keyword.put(previous_value, key, value)
+    Application.put_env(:prima_auth0_ex, :client, updated_value)
+
+    on_exit(fn ->
+      Application.put_env(:prima_auth0_ex, :client, previous_value)
+    end)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,14 +4,19 @@ ExUnit.start()
 defmodule PrimaAuth0Ex.TestHelper do
   import ExUnit.Callbacks
 
-  @spec set_client_env(term(), term(), boolean()) :: :ok
-  def set_client_env(key, value, false) do
+  @spec set_client_env(term(), term(), Keyword.t()) :: :ok
+  def set_client_env(key, value, opts \\ []) do
+    reset? = Keyword.get(opts, :reset?, true)
+    do_set_client_env(key, value, reset?)
+  end
+
+  defp do_set_client_env(key, value, false) do
     Application.get_env(:prima_auth0_ex, :client, [])
     |> Keyword.put(key, value)
     |> then(&Application.put_env(:prima_auth0_ex, :client, &1))
   end
 
-  def set_client_env(key, value, true) do
+  defp do_set_client_env(key, value, true) do
     previous_value = Application.get_env(:prima_auth0_ex, :client, [])
     updated_value = Keyword.put(previous_value, key, value)
     Application.put_env(:prima_auth0_ex, :client, updated_value)


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-578

This PR tries to handle decryption errors better i.e. instead of returning `{:ok, :error}`, return `{:error, "Failed to decrypt token"}`

I also added a CODEOWNERS file to try to see if we like it

