### PR TITLE
Do not disable certificate verification connecting to Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Breaking] Do not disable certificate verification connecting to Redis when the `redis_ssl_allow_wildcard_certificates` option is enabled.
+
 ---
 
 ## [0.4.6] - 2022-09-27

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -56,8 +56,7 @@ defmodule PrimaAuth0Ex.Application do
         socket_opts: [
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
-          ],
-          verify: :verify_none
+          ]
         ]
       )
     else


### PR DESCRIPTION
Related to:
* [DO-1331](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/DO-1331) Redis - Certificato SSL non correttamente verificato
* [MOTOR-1735](https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/MOTOR-1735) Update Redis 6 domain configuration and SSL settings