### PR TITLE
Fix an incorrect warning and improve/fix some docs

### DIFF
--- a/lib/prima_auth0_ex/absinthe/create_security_context.ex
+++ b/lib/prima_auth0_ex/absinthe/create_security_context.ex
@@ -1,7 +1,8 @@
 if Code.ensure_loaded?(Absinthe.Plug) do
   defmodule PrimaAuth0Ex.Absinthe.CreateSecurityContext do
     @moduledoc """
-    Plug that reads the permissions from the JWT token passed in the `Authorization` header and creates the security context.
+    Plug that reads the permissions from the JWT passed in the `Authorization` header and stores them in the Absinthe context,
+    so that they can be accessed by the `PrimaAuth0Ex.Absinthe.RequirePermissions` middleware.
 
     It does not validate the token! You should use the `PrimaAuth0Ex.Plug.VerifyAndValidateToken` plug to do that.
     """

--- a/lib/prima_auth0_ex/absinthe/create_security_context.ex
+++ b/lib/prima_auth0_ex/absinthe/create_security_context.ex
@@ -1,8 +1,9 @@
 if Code.ensure_loaded?(Absinthe.Plug) do
   defmodule PrimaAuth0Ex.Absinthe.CreateSecurityContext do
     @moduledoc """
-    Plug that reads the permissions from the received token and creates the security context.
-    It does not validate the token!
+    Plug that reads the permissions from the JWT token passed in the `Authorization` header and creates the security context.
+
+    It does not validate the token! You should use the `PrimaAuth0Ex.Plug.VerifyAndValidateToken` plug to do that.
     """
 
     defmodule Auth0 do

--- a/lib/prima_auth0_ex/absinthe/require_permissions.ex
+++ b/lib/prima_auth0_ex/absinthe/require_permissions.ex
@@ -2,7 +2,9 @@ if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Plug) do
   defmodule PrimaAuth0Ex.Absinthe.RequirePermissions do
     @moduledoc """
     Absinthe middleware that ensures that the given token permissions are included in the current security context.
-    If this is not the case and prima_auth0_ex is not running in "dry run" mode, it returns an `unauthorized` error.
+    If this is not the case, it returns an `unauthorized` error.
+
+    If prima_auth0_ex is configured to run in "dry run" mode, this middleware simply logs a warning when the context doesn't include the given permissions.
 
     This is meant to be used in conjunction with the `PrimaAuth0Ex.Absinthe.CreateSecurityContext` plug.
     """

--- a/lib/prima_auth0_ex/absinthe/require_permissions.ex
+++ b/lib/prima_auth0_ex/absinthe/require_permissions.ex
@@ -1,7 +1,10 @@
 if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Plug) do
   defmodule PrimaAuth0Ex.Absinthe.RequirePermissions do
     @moduledoc """
-    Absinthe middleware that ensure the permission is included in the current security context.
+    Absinthe middleware that ensures that the given token permissions are included in the current security context.
+    If this is not the case and prima_auth0_ex is not running in "dry run" mode, it returns an `unauthorized` error.
+
+    This is meant to be used in conjunction with the `PrimaAuth0Ex.Absinthe.CreateSecurityContext` plug.
     """
 
     require Logger

--- a/lib/prima_auth0_ex/absinthe/require_permissions.ex
+++ b/lib/prima_auth0_ex/absinthe/require_permissions.ex
@@ -32,7 +32,10 @@ if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Plug) do
            required_permissions
          ) do
       if permissions != nil do
-        Logger.warn("Received invalid token", required_permissions: required_permissions)
+        Logger.warn("Received token with incorrect permissions",
+          token_permissions: permissions,
+          required_permissions: required_permissions
+        )
       end
 
       resolution

--- a/lib/prima_auth0_ex/absinthe/require_permissions.ex
+++ b/lib/prima_auth0_ex/absinthe/require_permissions.ex
@@ -1,12 +1,13 @@
 if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Plug) do
   defmodule PrimaAuth0Ex.Absinthe.RequirePermissions do
     @moduledoc """
-    Absinthe middleware that ensures that the given token permissions are included in the current security context.
+    Absinthe middleware that ensures that the client has the required JWT permissions to access the GraphQL field.
     If this is not the case, it returns an `unauthorized` error.
 
-    If prima_auth0_ex is configured to run in "dry run" mode, this middleware simply logs a warning when the context doesn't include the given permissions.
+    This middleware expects the required permissions of the field to be stored in the Absinthe context,
+    which can be done by using the `PrimaAuth0Ex.Absinthe.CreateSecurityContext` plug.
 
-    This is meant to be used in conjunction with the `PrimaAuth0Ex.Absinthe.CreateSecurityContext` plug.
+    If prima_auth0_ex is configured to run in "dry run" mode, this middleware simply logs a warning when the context doesn't include the given permissions.
     """
 
     require Logger

--- a/lib/prima_auth0_ex/plug/verify_and_validate_token.ex
+++ b/lib/prima_auth0_ex/plug/verify_and_validate_token.ex
@@ -5,19 +5,21 @@ if Code.ensure_loaded?(Plug) do
 
     Usage:
 
-      plug PrimaAuth0Ex.Plug.VerifyAndValidateToken, required_permissions: ["some:permission"]
+    ```
+    plug PrimaAuth0Ex.Plug.VerifyAndValidateToken, required_permissions: ["some:permission"]
+    ```
 
     ## Options
 
     The following options can be set to customize the behavior of this plug:
 
-    * `audience: "my-audience"` sets the expected audience. Defaults to the audience set in `config.exs`.
-    * `required_permissions: ["p1", "p2"]` sets the set of permissions that clients are required to have.
+    * `required_permissions: ["p1", "p2"]` **(mandatory)**: sets the permissions that clients are required to have.
       Clients who do not have **all** the required permissions are forbidden from accessing the API.
-      Default is `[]`, ie. no permissions required, overridable from `config.exs`.
-    * `dry_run: false` when true allows clients to access the API even when their token is missing/invalid.
+      If you don't want to require any permissions, you can pass an empty list (`[]`) to this option.
+    * `audience: "my-audience"`: sets the expected audience. Defaults to the audience set in `config.exs`.
+    * `dry_run: false`: when true allows clients to access the API even when their token is missing/invalid.
       Mostly useful for testing purposes. Default is `false`, overridable from `config.exs`.
-    * `ignore_signature: false` when true, validates claims found in a token without verifying its signature.
+    * `ignore_signature: false`: when true, validates claims found in a token without verifying its signature.
       Should only be enabled in dev/test environments, as it allows anyone to forge valid tokens.
       Default is `false`, overridable from `config.exs`.
     """


### PR DESCRIPTION
I've noticed an incorrect/misleading warning message printed by the `RequirePermissions` middleware for Absinthe, when the lib is running in dry run mode and the given token contains incorrect permissions.
While I was at it, I've improved some docs related to the Absinthe middleware/plugs and fixed some outdated info.