### PR TITLE
Bump min elixir version to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/prima/elixir:1.12.2-2
+FROM public.ecr.aws/prima/elixir:1.13.4-4
 
 USER root
 WORKDIR /drone/src

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule PrimaAuth0Ex.MixProject do
     [
       app: :prima_auth0_ex,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),


### PR DESCRIPTION
[Joken 2.6.0 bumped its min version from 1.10 to 1.13](https://diff.hex.pm/diff/joken/2.5.0..2.6.0#84732810--12), we need to do the same