### PR TITLE
Remove `Logger.warn` calls

### DIFF
--- a/lib/prima_auth0_ex/absinthe/require_permissions.ex
+++ b/lib/prima_auth0_ex/absinthe/require_permissions.ex
@@ -38,7 +38,7 @@ if Code.ensure_loaded?(Absinthe) and Code.ensure_loaded?(Absinthe.Plug) do
            required_permissions
          ) do
       if permissions != nil do
-        Logger.warn("Received token with incorrect permissions",
+        Logger.warning("Received token with incorrect permissions",
           token_permissions: permissions,
           required_permissions: required_permissions
         )

--- a/lib/prima_auth0_ex/plug/verify_and_validate_token.ex
+++ b/lib/prima_auth0_ex/plug/verify_and_validate_token.ex
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(Plug) do
           valid_token?(token, audience, required_permissions, ignore_signature)
 
         _other ->
-          Logger.warn("Authorization header malformed")
+          Logger.warning("Authorization header malformed")
           false
       end
     end
@@ -90,7 +90,7 @@ if Code.ensure_loaded?(Plug) do
           true
 
         {:error, error} ->
-          Logger.warn("Received invalid token",
+          Logger.warning("Received invalid token",
             audience: audience,
             required_permissions: required_permissions,
             error: inspect(error)

--- a/lib/prima_auth0_ex/token_provider.ex
+++ b/lib/prima_auth0_ex/token_provider.ex
@@ -200,7 +200,7 @@ defmodule PrimaAuth0Ex.TokenProvider do
         send(parent, {:set_token_for, audience, new_token})
 
       {:error, description} ->
-        Logger.warn("Error refreshing token", audience: audience, description: description)
+        Logger.warning("Error refreshing token", audience: audience, description: description)
     end
   end
 

--- a/lib/prima_auth0_ex/token_provider/auth0_authorization_service.ex
+++ b/lib/prima_auth0_ex/token_provider/auth0_authorization_service.ex
@@ -33,18 +33,18 @@ defmodule PrimaAuth0Ex.TokenProvider.Auth0AuthorizationService do
         {:ok, TokenInfo.from_jwt(access_token)}
 
       response ->
-        Logger.warn("Invalid response from Auth0", response: inspect(response))
+        Logger.warning("Invalid response from Auth0", response: inspect(response))
         {:error, :invalid_auth0_response}
     end
   end
 
   defp parse_response({:ok, %HTTPoison.Response{status_code: status_code}}) do
-    Logger.warn("Request to Auth0 failed", status_code: status_code)
+    Logger.warning("Request to Auth0 failed", status_code: status_code)
     {:error, :request_error}
   end
 
   defp parse_response({:error, message}) do
-    Logger.warn("Error sending request to Auth0", error: inspect(message))
+    Logger.warning("Error sending request to Auth0", error: inspect(message))
     {:error, message}
   end
 

--- a/lib/prima_auth0_ex/token_provider/encrypted_redis_token_cache.ex
+++ b/lib/prima_auth0_ex/token_provider/encrypted_redis_token_cache.ex
@@ -33,7 +33,7 @@ defmodule PrimaAuth0Ex.TokenProvider.EncryptedRedisTokenCache do
         decrypt_and_parse(cached_value)
 
       {:error, reason} ->
-        Logger.warn("Error retrieving token from redis.",
+        Logger.warning("Error retrieving token from redis.",
           audience: audience,
           key: key,
           reason: reason
@@ -70,7 +70,7 @@ defmodule PrimaAuth0Ex.TokenProvider.EncryptedRedisTokenCache do
       build_token(token_attributes)
     else
       {:error, message} ->
-        Logger.warn("Found invalid data on redis.", message: inspect(message))
+        Logger.warning("Found invalid data on redis.", message: inspect(message))
         {:error, message}
     end
   end


### PR DESCRIPTION
`Logger.warn` has been deprecated in elixir 1.15: https://hexdocs.pm/logger/1.15.0/Logger.html#warn/2. So this PR replaces such calls with calls to `Logger.warning`