### PR TITLE
[CMSSE-730]: Fix docs and warning for redis cache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,10 @@ Note that right now caching is assumed to be all-or-nothing with respect to mult
 Clients can be configured to use caching through Redis. To use caching you can use the following configuration:
 
 ```elixir
+# Enables cache on redis for tokens obtained from Auth0.
 config :prima_auth0_ex, :token_cache, EncryptedRedisTokenCache
 
 config :prima_auth0_ex, :redis,
-  # Enables cache on redis for tokens obtained from Auth0. Defaults to false.
-  enabled: true,
   # AES 256 key used to encrypt tokens on the shared cache.
   # Can be generated via `:crypto.strong_rand_bytes(32) |> Base.encode64()`.
   encryption_key: "uhOrqKvUi9gHnmwr60P2E1hiCSD2dtXK1i6dqkU4RTA=",

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -45,13 +45,13 @@ defmodule PrimaAuth0Ex.Application do
         instead
         """)
 
-      {true, :"Elixir.EncryptedRedisTokenCache"} ->
+      {true, _} ->
         Logger.warning("""
         The
           :prima_auth0_ex, :redis, :enabled option
         is deprecated.
         Setting
-          :prima_auth0_ex, token_cache: EncryptedRedisTokenCache
+          :prima_auth0_ex, token_cache: #{cache_provider}
         alone is sufficient
         """)
 

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -45,7 +45,7 @@ defmodule PrimaAuth0Ex.Application do
         instead
         """)
 
-      {true, :'Elixir.EncryptedRedisTokenCache'} ->
+      {true, :"Elixir.EncryptedRedisTokenCache"} ->
         Logger.warning("""
         The
           :prima_auth0_ex, :redis, :enabled option

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -37,12 +37,22 @@ defmodule PrimaAuth0Ex.Application do
         Application.put_env(:prima_auth0_ex, :token_cache, EncryptedRedisTokenCache)
 
         Logger.warning("""
-        The 
-          :prima_auth0_ex, :redis, :enabled option 
+        The
+          :prima_auth0_ex, :redis, :enabled option
         is deprecated.
         Set
-          :prima_auth0_ex, token_cache: EncryptedRedisTokenCache 
+          :prima_auth0_ex, token_cache: EncryptedRedisTokenCache
         instead
+        """)
+
+      {true, :'Elixir.EncryptedRedisTokenCache'} ->
+        Logger.warning("""
+        The
+          :prima_auth0_ex, :redis, :enabled option
+        is deprecated.
+        Setting
+          :prima_auth0_ex, token_cache: EncryptedRedisTokenCache
+        alone is sufficient
         """)
 
       {false, nil} ->

--- a/lib/prima_auth0_ex/application.ex
+++ b/lib/prima_auth0_ex/application.ex
@@ -27,9 +27,9 @@ defmodule PrimaAuth0Ex.Application do
 
   defp migrate_deprecated_cache_options do
     redis_enabled = Config.redis(:enabled)
-    cache_provieder = Config.token_cache(nil)
+    cache_provider = Config.token_cache(nil)
 
-    case {redis_enabled, cache_provieder} do
+    case {redis_enabled, cache_provider} do
       {nil, _} ->
         nil
 


### PR DESCRIPTION
The config as I copied it from the readme didn't work - and there wasn't a warning for it just a failed pattern match.

I've created this mood board to explain the problem:

<img width="1247" alt="Screenshot 2024-01-16 at 14 43 52" src="https://github.com/primait/auth0_ex/assets/8879326/99fac7aa-c063-4cae-bb18-adf14b56de63">

Could well be the case that I've misread something but gave it a go to fix it. Possibly pattern matching on `:'Elixir.EncryptedRedisTokenCache'` isn't very nice because I guess fully qualified or aliased module names wouldn't match - I can't think of a nicer solution though.