### PR TITLE
Add missing pattern match when creating dynamo db table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- DynamoDB cache raising if table already exists and ttl is enabled
+
 ---
 
 ## [0.9.3] - 2025-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.9.4] - 2025-06-05
+
 ### Fixed
 
 - DynamoDB cache raising if table already exists and ttl is enabled
@@ -350,7 +354,9 @@ Bug fixes
 
 
 
-[Unreleased]: https://github.com/primait/auth0_ex/compare/0.9.3...HEAD
+
+[Unreleased]: https://github.com/primait/auth0_ex/compare/0.9.4...HEAD
+[0.9.4]: https://github.com/primait/auth0_ex/compare/0.9.3...0.9.4
 [0.9.3]: https://github.com/primait/auth0_ex/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/primait/auth0_ex/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/primait/auth0_ex/compare/0.9.0...0.9.1

--- a/lib/prima_auth0_ex/token_cache/dynamodb.ex
+++ b/lib/prima_auth0_ex/token_cache/dynamodb.ex
@@ -116,6 +116,9 @@ defmodule PrimaAuth0Ex.TokenCache.DynamoDB do
 
       _ ->
         case table_name() |> Dynamo.describe_time_to_live() |> ExAws.request!() do
+          %{"TimeToLiveDescription" => %{"TimeToLiveStatus" => "ENABLED"}} ->
+            nil
+
           %{"TimeToLiveDescription" => %{"TimeToLiveStatus" => "DISABLED"}} ->
             table_name()
             |> Dynamo.update_time_to_live("expires_at", true)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PrimaAuth0Ex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/auth0_ex"
-  @version "0.9.3"
+  @version "0.9.4"
 
   def project do
     [


### PR DESCRIPTION
if table already exists and ttl is enabled the create_table function raises:

```elixir
** (Mix) Could not start application prima_auth0_ex: PrimaAuth0Ex.Application.start(:normal, []) returned an error: shutdown: failed to start child: PrimaAuth0Ex.TokenCache.DynamoDB
    ** (EXIT) an exception was raised:
        ** (CaseClauseError) no case clause matching: %{"TimeToLiveDescription" => %{"AttributeName" => "expires_at", "TimeToLiveStatus" => "ENABLED"}}
            (prima_auth0_ex 0.9.1) lib/prima_auth0_ex/token_cache/dynamodb.ex:118: PrimaAuth0Ex.TokenCache.DynamoDB.create_update_table/0
            (prima_auth0_ex 0.9.1) lib/prima_auth0_ex/token_cache/dynamodb.ex:63: PrimaAuth0Ex.TokenCache.DynamoDB.start/0
            (stdlib 6.1.2) supervisor.erl:959: :supervisor.do_start_child_i/3
            (stdlib 6.1.2) supervisor.erl:945: :supervisor.do_start_child/3
            (stdlib 6.1.2) supervisor.erl:929: anonymous fn/3 in :supervisor.start_children/2
            (stdlib 6.1.2) supervisor.erl:1820: :supervisor.children_map/4
            (stdlib 6.1.2) supervisor.erl:889: :supervisor.init_children/2
            (stdlib 6.1.2) gen_server.erl:2229: :gen_server.init_it/2
            (stdlib 6.1.2) gen_server.erl:2184: :gen_server.init_it/6
            (stdlib 6.1.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3

```