### PR TITLE
Migrate bitnami redis image to DockerHub one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
     services:
       redis:
-        image: 279066465364.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/redis:5.0
+        image: docker.io/redis:5.0
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - localauth0
 
   redis:
-    image: 279066465364.dkr.ecr.eu-west-1.amazonaws.com/docker-hub/library/redis:5.0
+    image: docker.io/redis:5.0
     ports:
       - "6379:6379"
     hostname: "redis"


### PR DESCRIPTION

Bitnami recently [annouced](https://github.com/bitnami/containers/issues/83267) changes regarding their open-source docker images. 

We decided to react migrating away from their images, toward the upstream image [redis from dockerhub](https://hub.docker.com/_/redis)

This is part of the effor to migrate them all, expect then other PRs for the remaining bitnami images.

We have a tight schedule, because we want to be sure to hit the deadline of the 28th of August.

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/DO-3726/Migration-of-upcoming-Bitnami-docker-images-charts-deprecation